### PR TITLE
Fixed typing issue with pyslsqp callable option

### DIFF
--- a/modopt/external_libraries/pyslsqp/pyslsqp.py
+++ b/modopt/external_libraries/pyslsqp/pyslsqp.py
@@ -2,6 +2,7 @@ import numpy as np
 from modopt import Optimizer
 import time
 from modopt.utils.options_dictionary import OptionsDictionary
+from typing import Callable
 
 class PySLSQP(Optimizer):
     '''
@@ -50,7 +51,7 @@ class PySLSQP(Optimizer):
             'maxiter': (int, 100),
             'acc': (float, 1e-6),
             'iprint': (int, 1),
-            'callback': ((type(None), callable), None),
+            'callback': ((type(None), Callable), None),
             'summary_filename': (str, 'slsqp_summary.out'),
             'visualize': (bool, False),
             'visualize_vars': (list, ['objective', 'optimality', 'feasibility']),


### PR DESCRIPTION
## Summary
### Overview
Python's callable isn't actually a type, causing an error when this option is specified. Changed to typing.Callable.

## Changes (Check all boxes that apply)
- [ ] Added tests
- [ ] Added examples
- [ ] Updated docs
- [ ] Refactor code
- [ ] Added functionality
- [x] Fixed bugs (Patch version increase)
- [ ] Changed API (Major/Minor version increase)
- [ ] New release (Major/Minor/Patch version increase)

## Checklist
<!-- Make sure PR will have minimal conflicts -->
- All existing tests pass
- No local merge conflicts
- Code is commented
- Tests written for new features (if needed)
- Version number is updated (if needed)

<!-- OPTIONAL: -->
## Optional
### Related Github Issues

- Resolves # 

### New Dependencies

None
